### PR TITLE
Automates DNS managaement with Concourse

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -5,7 +5,7 @@ export WORK_DIR=${PROJECT_DIR}/work
 PATH=${PROJECT_DIR}/bin:${PATH}
 
 # for terraforming DNS
-export GOOGLE_CREDENTIALS=${PROJECT_DIR}/secrets/terraform-shortrib-dev.json
+export GOOGLE_CREDENTIALS=${PROJECT_DIR}/secrets/$(basename ${PROJECT_DIR}).json
 export TF_VAR_project=shortrib
 export TF_VAR_gcp_key=${GOOGLE_CREDENTIALS}
 export TF_VAR_region=us-west-1

--- a/bin/populate-vault
+++ b/bin/populate-vault
@@ -5,5 +5,5 @@ put-secret --team network --pipeline "$(basename ${PROJECT_DIR})" \
   --var google-credentials "$(cat ${SECRETS_DIR}/$(basename ${PROJECT_DIR}.json))"
 
 put-secret --team network --pipeline "$(basename ${PROJECT_DIR})" \
-  --var gcs region="us-west-1" bucket="$(basename ${PROJECT_DIR}.json)" prefix="teraform/state"
+  --var gcs region="us-west-1" bucket="$(basename ${PROJECT_DIR})" prefix="terraform/state"
   

--- a/bin/populate-vault
+++ b/bin/populate-vault
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+put-secret --team network --pipeline "$(basename ${PROJECT_DIR})" \
+  --var google-credentials "$(cat ${SECRETS_DIR}/$(basename ${PROJECT_DIR}.json))"
+
+put-secret --team network --pipeline "$(basename ${PROJECT_DIR})" \
+  --var gcs region="us-west-1" bucket="$(basename ${PROJECT_DIR}.json)" prefix="teraform/state"
+  

--- a/bin/put-secret
+++ b/bin/put-secret
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+
+import os
+import subprocess
+
+from typing import List
+import typer
+
+secrets_dir = os.environ.get("SECRETS_DIR")
+root = "concourse"
+
+def main(team: str = typer.Option(..., "--team", help="Name of the team to which the pipeline belongs"), 
+    pipeline: str = typer.Option("", "--pipeline", "-p", help="Pipeline the parameter is for" ),
+    parameter: str = typer.Option(..., "--var", "-v", help="Pipeline variable to store in vault"),
+    values: List[str] = typer.Argument(..., help="Values to set ohn the pipeline variable")):
+  """
+  Populates vault with secrets required for the pipeline
+
+  If --pipeline is provided, they will be at the pipeline level, 
+  if omitted they'll be set at the team level
+  """
+  prefix = f"{root}/{team}"
+  if pipeline:
+    prefix = f"{prefix}/{pipeline}"
+
+  items = {}
+  for value in values:
+    key = "value"
+    if "=" in value:
+      key, value = value.split("=")
+    items.update({ key: value })
+  __put_secret(f"{prefix}/{parameter}", **items)
+
+def __put_secret(path, **kwargs):
+  values = [] 
+  for key, value in kwargs.items():
+    values.append(f"{key}={value}")
+  subprocess.run(["vault", "kv", "put", path] + values)
+  
+if __name__ == "__main__":
+   typer.run(main) 

--- a/src/pipeline/params.yml
+++ b/src/pipeline/params.yml
@@ -1,3 +1,3 @@
 git:
-  repository: shortrib-net/terraform-dns-shortrib-dev.git
+  repository: https://github.com/shortrib-net/terraform-dns-shortrib-dev.git
   branch: feature-automation

--- a/src/pipeline/params.yml
+++ b/src/pipeline/params.yml
@@ -1,0 +1,3 @@
+git:
+  repository: shortrib-net/terraform-dns-shortrib-dev.git
+  branch: feature-automation

--- a/src/pipeline/parmas.yml
+++ b/src/pipeline/parmas.yml
@@ -1,0 +1,3 @@
+git:
+  repository: shortrib-net/terraform-dns-shortirb-dev
+

--- a/src/pipeline/pipeline.yml
+++ b/src/pipeline/pipeline.yml
@@ -1,7 +1,7 @@
 ---
 resources:
 # The repo with the DNS source
-- name: dns-shortrib-dev-source
+- name: source
   type: git
   icon: github
   source:
@@ -9,23 +9,31 @@ resources:
     branch: ((git.branch))
 
 # The repo with the DNS source
-- name: dns-shortrib-dev-records
+- name: records
   type: terraform
   icon: terraform
   source:
+    env_name: default
+    vars:
+      project: shortrib
+      region: ((gcs.region))
+    env:
+      GOOGLE_CREDENTIALS: ((google-credentials))
     backend_type: gcs
     backend_config:
       bucket: ((gcs.bucket)) 
       prefix: ((gcs.prefix))
-      region: ((gcs.region))
+      # region: ((gcs.region))
       credentials: ((google-credentials))
 
 jobs:
 - name: update-dns
   plan:
-  - get: dns-shortrib-dev-source
+  - get: source
     trigger: true
-  - put: dns-shortrib-dev-records
+  - put: records
+    params:
+      terraform_source: source/src/terraform
 
 
 resource_types:

--- a/src/pipeline/pipeline.yml
+++ b/src/pipeline/pipeline.yml
@@ -1,0 +1,36 @@
+---
+resources:
+# The repo with the DNS source
+- name: dns-shortrib-dev-source
+  type: git
+  icon: github
+  source:
+    uri: ((git.repository))
+    branch: ((git.branch))
+
+# The repo with the DNS source
+- name: dns-shortrib-dev-records
+  type: terraform
+  icon: terraform
+  source:
+    backend_type: gcs
+    backend_config:
+      bucket: ((gcs.bucket)) 
+      prefix: ((gcs.prefix))
+      region: ((gcs.region))
+      credentials: ((google-credentials))
+
+jobs:
+- name: update-dns
+  plan:
+  - get: dns-shortrib-dev-source
+    trigger: true
+  - put: dns-shortrib-dev-records
+
+
+resource_types:
+- name: terraform
+  type: registry-image
+  source:
+    repository: ljfranklin/terraform-resource
+    tag: latest

--- a/src/terraform/.terraform.lock.hcl
+++ b/src/terraform/.terraform.lock.hcl
@@ -4,6 +4,7 @@
 provider "registry.terraform.io/hashicorp/google" {
   version = "4.3.0"
   hashes = [
+    "h1:WUNW3/N92D5I73S3L29lbfDrU8EmuCozwrewRjD1EBE=",
     "h1:cWwVdiGkvkcK98X1AjyRMy87l6ICd4jlUX7uKDiBAT0=",
     "zh:06b8930d0ee2167f66e19ee8968c6eb58ff0251ca7ad582919cbfff8c1d4afbd",
     "zh:4054cde9467def8a270c5dd240404771e0ed31cba69382d75331226a2559c47a",


### PR DESCRIPTION
TL;DR
-----

Adds a Concourse pipeline to manage DNS

Details
-------

Implementes a simple pipeline to automation DNS management for the
domain. Includes a couple of convenience shell scripts for seeting
up Vault secrets needed by the pipeline. Run `populate-vault` to 
set/update the secrets.
