### PR TITLE
Updates for new Tailscale host names for proxies

### DIFF
--- a/src/terraform/main.tf
+++ b/src/terraform/main.tf
@@ -52,6 +52,6 @@ resource "google_dns_record_set" "kubernetes" {
   ttl          = 60
 
   rrdatas = [
-    "shared-services.crdant.io.beta.tailscale.net."
+    "arbol.crdant.io.beta.tailscale.net."
   ]
 }


### PR DESCRIPTION
TL;DR
-----

Points Kubernetes service resolution toward the right Tailscale
host

Details
-------

Makes DNS match the recent change to Tailscale proxy setup that
uses the cluster name for the Tailscale hostname rather than the
cluser role.
